### PR TITLE
Feat(Live Stream) Enable youtube live option in Jitsi

### DIFF
--- a/public/jitsi.html
+++ b/public/jitsi.html
@@ -19,7 +19,7 @@
             configOverwrite: {},
             interfaceConfigOverwrite: {
               filmStripOnly: false,
-                TOOLBAR_BUTTONS: ['microphone', 'camera', 'closedcaptions', 'desktop', 'fullscreen',
+                TOOLBAR_BUTTONS: ['microphone', 'camera', 'closedcaptions', 'desktop', 'fullscreen', 'livestreaming',
                   'fodeviceselection', 'hangup', 'profile', 'chat', 'recording', 'settings', 'raisehand','videoquality', 'filmstrip', 'stats', 
                   'tileview', 'videobackgroundblur',  'mute-everyone'],
               },


### PR DESCRIPTION
# How to?
- Create an Event on youtube

![image](https://user-images.githubusercontent.com/21258010/81840905-3f09d300-9567-11ea-87d5-1118b9bfef02.png)

- Copy the event Key then create any jisi meeting
- Open more options
![image](https://user-images.githubusercontent.com/21258010/81840618-e20e1d00-9566-11ea-9d30-46acc30a2d46.png)
- Paste your youtube key here
![image](https://user-images.githubusercontent.com/21258010/81841173-a9227800-9567-11ea-8abe-8e3f31f27c4d.png)
- Start Event from youtube
