### PR TITLE
Fix(Course) show a message in place of codesandbox editor if code not set

### DIFF
--- a/src/pages/VideoCourse.vue
+++ b/src/pages/VideoCourse.vue
@@ -12,6 +12,7 @@
           sm="12"
         >
           <Checkbox
+            v-if="codeEditorURL"
             id="isautoSync"
             label="Auto sync code with video"
             :is-checked="isAutoSync"
@@ -36,7 +37,11 @@
           md="6"
           sm="12"
         >
-          <CodeEditor :url="codeEditorURL" />
+          <CodeEditor
+            v-if="codeEditorURL"
+            :url="codeEditorURL"
+          />
+          <span v-else>No code available for this topic</span>
         </b-col>
       </b-row>
       <b-row


### PR DESCRIPTION
Fixes: https://github.com/shoonyatech/frontend.social/issues/358

![image](https://user-images.githubusercontent.com/21258010/86534669-b587d900-bef7-11ea-8a71-d35867b0c152.png)
